### PR TITLE
feat: add process pool to parrallelize printing process

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Common options:
       --excludeUrls, --exclude-urls                   Exclude urls matching a regex from printing process       [string]
       --safeTitle, --safe-title                       Safely generate file title by replacing special chars
                                                                                               [boolean] [default: false]
+      --processPool, --process-pool                   Pool of parallelized process                [number] [default: 10]
 
 Other Options:
       --debug    Turn on debug logging                                                        [boolean] [default: false]
@@ -74,6 +75,8 @@ Examples:
   website2pdf --chromium-flags="--no-sandbox                    Use specific chromium options at Puppeteer launch
   --disable-dev-shm-usage"
   website2pdf --exclude-urls="\/fr\/"                           Exclude urls of french language
+  website2pdf --safe-title                                      Safely generate file title by replacing special chars
+  website2pdf --process-pool                                    Use specific count of parallelized process
 
 Additional information:
   GitHub: https://github.com/jgazeau/website2pdf.git

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
+        "@supercharge/promise-pool": "^2.3.2",
         "axios": "^0.27.2",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.13.2",
@@ -313,6 +314,14 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
+    },
+    "node_modules/@supercharge/promise-pool": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@supercharge/promise-pool/-/promise-pool-2.3.2.tgz",
+      "integrity": "sha512-f5+C7zv+QQivcUO1FH5lXi7GcuJ3CFuJF3Eg06iArhUs5ma0szCLEQwIY4+VQyh7m/RLVZdzvr4E4ZDnLe9MNg==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
@@ -4944,6 +4953,11 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
+    },
+    "@supercharge/promise-pool": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@supercharge/promise-pool/-/promise-pool-2.3.2.tgz",
+      "integrity": "sha512-f5+C7zv+QQivcUO1FH5lXi7GcuJ3CFuJF3Eg06iArhUs5ma0szCLEQwIY4+VQyh7m/RLVZdzvr4E4ZDnLe9MNg=="
     },
     "@tsconfig/node10": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "homepage": "https://github.com/jgazeau/website2pdf#readme",
   "dependencies": {
+    "@supercharge/promise-pool": "^2.3.2",
     "axios": "^0.27.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",

--- a/src/cli/iArgumentsParser.ts
+++ b/src/cli/iArgumentsParser.ts
@@ -18,4 +18,5 @@ export interface ICliArguments extends Arguments {
   chromiumFlags: string;
   excludeUrls: string;
   safeTitle: boolean;
+  processPool: number;
 }

--- a/src/cli/website2pdfCli.ts
+++ b/src/cli/website2pdfCli.ts
@@ -15,6 +15,7 @@ import {
   MARGIN_RIGHT_OPTION,
   MARGIN_TOP_OPTION,
   OUTPUT_DIR_OPTION,
+  PROCESS_POOL_OPTION,
   SAFE_TITLE_OPTION,
   SITEMAP_URL_OPTION,
   TEMPLATE_DIR_OPTION,
@@ -89,6 +90,14 @@ export class Website2PdfCli {
         [
           `$0 --${EXCLUDE_URLS_OPTION}="\\/fr\\/"`,
           'Exclude urls of french language',
+        ],
+        [
+          `$0 --${SAFE_TITLE_OPTION}`,
+          'Safely generate file title by replacing special chars',
+        ],
+        [
+          `$0 --${PROCESS_POOL_OPTION}`,
+          'Use specific count of parallelized process',
         ],
       ])
       .options({
@@ -178,6 +187,14 @@ export class Website2PdfCli {
           default: false,
           description: 'Safely generate file title by replacing special chars',
           group: this.GROUPS.COMMONS,
+        },
+        processPool: {
+          alias: [`${PROCESS_POOL_OPTION}`],
+          type: 'number',
+          default: 10,
+          description: 'Pool of parallelized process',
+          group: this.GROUPS.COMMONS,
+          nargs: 1,
         },
       })
       .wrap(getOutputWidth())

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -14,6 +14,7 @@ export const MARGIN_RIGHT_OPTION = 'margin-right';
 export const CHROMIUM_FLAGS_OPTION = 'chromium-flags';
 export const EXCLUDE_URLS_OPTION = 'exclude-urls';
 export const SAFE_TITLE_OPTION = 'safe-title';
+export const PROCESS_POOL_OPTION = 'process-pool';
 
 export const DEFAULT_TEMPLATE_DIR = './w2pdf_template';
 export const DEFAULT_OUTPUT_DIR = './w2pdf_output';
@@ -27,6 +28,7 @@ export const DEFAULT_SITEMAP_NAME = 'sitemap.xml';
 export const DEFAULT_SITEMAP_HOST = `http://${DEFAULT_HOST}:${DEFAULT_PORT}`;
 export const DEFAULT_SITEMAP_URL = `${DEFAULT_SITEMAP_HOST}/${DEFAULT_SITEMAP_NAME}`;
 export const DEFAULT_SAFE_TITLE = false;
+export const DEFAULT_PROCESS_POOL = 10;
 export const fxpOptions = {
   ignoreAttributes: true,
   parseNodeValue: true,

--- a/test/cli/test-website2pdfCli.ts
+++ b/test/cli/test-website2pdfCli.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_MARGIN_MAX,
   DEFAULT_MARGIN_MIN,
   DEFAULT_OUTPUT_DIR,
+  DEFAULT_PROCESS_POOL,
   DEFAULT_SAFE_TITLE,
   DEFAULT_SITEMAP_URL,
   DEFAULT_TEMPLATE_DIR,
@@ -17,6 +18,7 @@ import {
   MARGIN_RIGHT_OPTION,
   MARGIN_TOP_OPTION,
   OUTPUT_DIR_OPTION,
+  PROCESS_POOL_OPTION,
   SAFE_TITLE_OPTION,
   SITEMAP_URL_OPTION,
   TEMPLATE_DIR_OPTION,
@@ -25,6 +27,7 @@ import {
   SPECIFIC_CHROMIUM_FLAGS,
   SPECIFIC_DIR,
   SPECIFIC_EXCLUDE_REGEX,
+  SPECIFIC_PROCESS_POOL,
   SPECIFIC_URL,
 } from '../testUtils/const';
 import {mockArgs, setChaiAsPromised} from '../testUtils/helpers';
@@ -82,6 +85,7 @@ describe('Website2Pdf CLI tests', () => {
       expect(argv.marginLeft).to.be.equal(DEFAULT_MARGIN_MIN);
       expect(argv.marginRight).to.be.equal(DEFAULT_MARGIN_MIN);
       expect(argv.safeTitle).to.be.equal(DEFAULT_SAFE_TITLE);
+      expect(argv.processPool).to.be.equal(DEFAULT_PROCESS_POOL);
       const website: Website = new Website();
       expect(website.websiteURL.sitemapURL.toString()).to.equal(
         DEFAULT_SITEMAP_URL
@@ -270,6 +274,18 @@ describe('Website2Pdf CLI tests', () => {
       expect(argv.excludeUrls).to.be.equal(SPECIFIC_EXCLUDE_REGEX);
     });
   });
+  it(`parse should display error and exit when ${EXCLUDE_URLS_OPTION} option is empty`, () => {
+    setChaiAsPromised();
+    sinonMock.consoleError = true;
+    sinonMock.processExit = true;
+    sinonMock.sinonSetStubs();
+    mockArgs([`--${EXCLUDE_URLS_OPTION}`]);
+    const cli = new Website2PdfCli();
+    return cli.parse().then(() => {
+      expect(console.error).to.be.called;
+      expect(process.exit).to.be.called;
+    });
+  });
   it(`parse should have specific ${SAFE_TITLE_OPTION} argument when ${SAFE_TITLE_OPTION} option`, () => {
     setChaiAsPromised();
     mockArgs([`--${SAFE_TITLE_OPTION}`]);
@@ -278,12 +294,20 @@ describe('Website2Pdf CLI tests', () => {
       expect(argv.safeTitle).to.be.equal(true);
     });
   });
-  it(`parse should display error and exit when ${EXCLUDE_URLS_OPTION} option is empty`, () => {
+  it(`parse should have specific ${PROCESS_POOL_OPTION} argument when ${PROCESS_POOL_OPTION} option`, () => {
+    setChaiAsPromised();
+    mockArgs([`--${PROCESS_POOL_OPTION}=${SPECIFIC_PROCESS_POOL}`]);
+    const cli = new Website2PdfCli();
+    return cli.parse().then(argv => {
+      expect(argv.processPool).to.be.equal(SPECIFIC_PROCESS_POOL);
+    });
+  });
+  it(`parse should display error and exit when ${PROCESS_POOL_OPTION} option is empty`, () => {
     setChaiAsPromised();
     sinonMock.consoleError = true;
     sinonMock.processExit = true;
     sinonMock.sinonSetStubs();
-    mockArgs([`--${EXCLUDE_URLS_OPTION}`]);
+    mockArgs([`--${PROCESS_POOL_OPTION}`]);
     const cli = new Website2PdfCli();
     return cli.parse().then(() => {
       expect(console.error).to.be.called;

--- a/test/testUtils/const.ts
+++ b/test/testUtils/const.ts
@@ -6,6 +6,7 @@ import {ICliArguments} from '../../src/cli/iArgumentsParser';
 import {
   DEFAULT_MARGIN_MIN,
   DEFAULT_OUTPUT_DIR,
+  DEFAULT_PROCESS_POOL,
   DEFAULT_SITEMAP_HOST,
   DEFAULT_SITEMAP_NAME,
   DEFAULT_SITEMAP_URL,
@@ -37,6 +38,7 @@ export const SPECIFIC_URL = `https://example.com/${DEFAULT_SITEMAP_NAME}`;
 export const SPECIFIC_DIR = './aSpecificDir/';
 export const SPECIFIC_CHROMIUM_FLAGS = '--no-sandbox';
 export const SPECIFIC_EXCLUDE_REGEX = '\\/fr\\/';
+export const SPECIFIC_PROCESS_POOL = 20;
 export const DUMMY_CLIARGS: ICliArguments = {
   _: [],
   $0: '',
@@ -52,6 +54,7 @@ export const DUMMY_CLIARGS: ICliArguments = {
   marginBottom: DEFAULT_MARGIN_MIN,
   chromiumFlags: '',
   safeTitle: false,
+  processPool: DEFAULT_PROCESS_POOL,
 };
 
 export const ABSOLUTE_URL = 'absolute/url';


### PR DESCRIPTION
The generation of PDFs is now parallelized and triggered using a pool of promises. This avoid opening too much pages and leads to memory issues.
Also add a new option to be able to specify the number of parallel process to use. By default 10 is used.
Close #48 