### PR TITLE
Paper size option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 This tool aims to **print pages from a website into PDF files**.  
 To achieve that, the website **must follow the [sitemap protocol](https://www.sitemaps.org/protocol.html)**.
 
-*NB: this tool was originally created to print pages from a Hugo website, that's why the default value of the sitemap URL to check is **http://localhost:1313**.*
+_NB: this tool was originally created to print pages from a Hugo website, that's why the default value of the sitemap URL to check is **http://localhost:1313**._
 
 ## How it works?
 
-* Website2pdf will crawl the website based on the **sitemapUrl** option to retrieve all URLs that have to be printed
-* Website2pdf will add header/footer in each file based on the **displayHeaderFooter** option, and use **header.html** and **footer.html** if found in the directory based on the **templateDir** option.
-* Website2pdf will save all PDF file in the directory based on the **outputDir** option.
-* Generated PDFs are named using the `<title>` html tag by default (unless specific option is used)
+- Website2pdf will crawl the website based on the **sitemapUrl** option to retrieve all URLs that have to be printed
+- Website2pdf will add header/footer in each file based on the **displayHeaderFooter** option, and use **header.html** and **footer.html** if found in the directory based on the **templateDir** option.
+- Website2pdf will save all PDF file in the directory based on the **outputDir** option.
+- Generated PDFs are named using the `<title>` html tag by default (unless specific option is used)
 
 ## How to use it?
 
@@ -51,7 +51,6 @@ Common options:
   -t, --templateDir, --template-dir                   Relative path of the templates directory
                                                                                            [default: "./w2pdf_template"]
   -o, --outputDir, --output-dir                       Relative path of the output directory  [default: "./w2pdf_output"]
-      --pageSize, --page-size                         Page size / PaperFormat                   [string] [default: "a4"]
       --marginTop, --margin-top                       Margin top (50px or 0px)                                  [string]
       --marginBottom, --margin-bottom                 Margin bottom (50px or 0px)                               [string]
       --marginLeft, --margin-left                     Margin left                              [string] [default: "0px"]
@@ -62,6 +61,7 @@ Common options:
                                                                                               [boolean] [default: false]
       --urlTitle, --url-title                         Generate file title using last URL fragment
                                                                                               [boolean] [default: false]
+      --format, --format                              Set PaperFormat of generated PDF          [string] [default: "a4"]
       --processPool, --process-pool                   Pool of parallelized process                [number] [default: 10]
       --serveSitemap, --serve-sitemap                 Serve local sitemap                                       [string]
 
@@ -71,18 +71,19 @@ Other Options:
   -h, --help     Show help                                                                                     [boolean]
 
 Examples:
-  website2pdf --sitemap-url "http://localhost:80/sitemap.xml"   Use specific sitemap URL
+  website2pdf --sitemap-url="http://localhost:80/sitemap.xml"   Use specific sitemap URL
   website2pdf --display-header-footer                           Print PDFs with header and footer
-  website2pdf --template-dir "./templates"                      Use specific template directory
-  website2pdf --output-dir "./output"                           Use specific output directory
-  website2pdf --display-header-footer --margin-left "50px"      Use header and footer and set specific margins
-  --margin-right "50px"
+  website2pdf --template-dir="./templates"                      Use specific template directory
+  website2pdf --output-dir="./output"                           Use specific output directory
+  website2pdf --format="a3"                                     Set PaperFormat type
+  website2pdf --display-header-footer --margin-left="50px"      Use header and footer and set specific margins
+  --margin-right="50px"
   website2pdf --chromium-flags="--no-sandbox                    Use specific chromium options at Puppeteer launch
   --disable-dev-shm-usage"
   website2pdf --exclude-urls="\/fr\/"                           Exclude urls of french language
   website2pdf --safe-title                                      Safely generate file title by replacing special chars
   website2pdf --url-title                                       Generate file title using last URL fragment
-  website2pdf --process-pool                                    Use specific count of parallelized process
+  website2pdf --process-pool=20                                 Use specific count of parallelized process
   website2pdf --serve-sitemap="sitemap.xml"                     Serve a local sitemap
 
 Additional information:
@@ -97,17 +98,17 @@ Additional information:
 
 ```
 $ npx website2pdf
-2022-01-01 00:00:00.000  INFO 
+2022-01-01 00:00:00.000  INFO
 ●      __          __  _         _ _       ___  _____    _  __
 ●      \ \        / / | |       (_) |     |__ \|  __ \  | |/ _|
 ●       \ \  /\  / /__| |__  ___ _| |_ ___   ) | |__) |_| | |_
 ●        \ \/  \/ / _ \ '_ \/ __| | __/ _ \ / /|  ___/ _` |  _|
 ●         \  /\  /  __/ |_) \__ \ | ||  __// /_| |  | (_| | |
 ●          \/  \/ \___|_.__/|___/_|\__\___|____|_|   \__,_|_|
- 
-2022-01-01 00:00:00.000  INFO Printing 2 PDF(s) to w2pdf_output\fr 
+
+2022-01-01 00:00:00.000  INFO Printing 2 PDF(s) to w2pdf_output\fr
 2022-01-01 00:00:00.000  INFO Printing 2 PDF(s) to w2pdf_output\en
-2022-01-01 00:00:00.000  INFO 
+2022-01-01 00:00:00.000  INFO
 ┌───────────────────────────────────────────────────────────────┐
 │                   Results summary                             │
 ├─────────────────┬───────────────────────────────────┬─────────┤
@@ -129,67 +130,69 @@ You can choose the page dimension / page size with the `--pageSize` option. The 
 
 To include specific header and footer in PDF pages, two HTML files must be provided, named respectively **header.html** and **footer.html** (in **./w2pdf_template** by default).
 
-Because of a [limitation in puppeteer](https://github.com/puppeteer/puppeteer/issues/1853), a default margin must be set (at least for top and bottom) to display headers and footers.  
+Because of a [limitation in puppeteer](https://github.com/puppeteer/puppeteer/issues/1853), a default margin must be set (at least for top and bottom) to display headers and footers.
 
 By default website2pdf is setting the following margins depending on the `displayHeaderFooter` option (these default values can be override using the `marginX` options of website2pdf):
-* `displayHeaderFooter=false`
-    ```
-     ⬌ 0px      0px ⬌
-    ┌──┬───────────┬───┐
-    │  │           │   │⬍ 0px
-    ├──┼───────────┼───┤
-    │  │           │   │
-    │  │           │   │
-    │  │           │   │
-    │  │           │   │
-    ├──┼───────────┼───┤
-    │  │           │   │⬍ 0px
-    └──┴───────────┴───┘
-    ```
-* `displayHeaderFooter=true`
-    ```
-     ⬌ 0px      0px ⬌
-    ┌──┬───────────┬───┐
-    │  │           │   │⬍ 50px
-    ├──┼───────────┼───┤
-    │  │           │   │
-    │  │           │   │
-    │  │           │   │
-    │  │           │   │
-    ├──┼───────────┼───┤
-    │  │           │   │⬍ 50px
-    └──┴───────────┴───┘
-    ```
+
+- `displayHeaderFooter=false`
+  ```
+   ⬌ 0px      0px ⬌
+  ┌──┬───────────┬───┐
+  │  │           │   │⬍ 0px
+  ├──┼───────────┼───┤
+  │  │           │   │
+  │  │           │   │
+  │  │           │   │
+  │  │           │   │
+  ├──┼───────────┼───┤
+  │  │           │   │⬍ 0px
+  └──┴───────────┴───┘
+  ```
+- `displayHeaderFooter=true`
+  ```
+   ⬌ 0px      0px ⬌
+  ┌──┬───────────┬───┐
+  │  │           │   │⬍ 50px
+  ├──┼───────────┼───┤
+  │  │           │   │
+  │  │           │   │
+  │  │           │   │
+  │  │           │   │
+  ├──┼───────────┼───┤
+  │  │           │   │⬍ 50px
+  └──┴───────────┴───┘
+  ```
 
 The following types of configurations are available to expand header and footer:
-* standard options of [headerTemplate and footerTemplate from Puppeteer](https://devdocs.io/puppeteer/index#pagepdfoptions)
-* expanded variables from meta tags of HTML page:
-    * Given the following HTML meta tag (using a `${META_KEY}` as a placeholder):
-        ```
-        <meta name="specificKey" content="A specific value">
-        ```
-        And the following header and/or footer template:
-        ```
-        ...
-        <span>${specificKey}</span>
-        ...
-        ```
-        The result template will be:
-        ```
-        ...
-        <span>A specific value</span>
-        ...
-        ```
-* images encoded as _base64_ from local files (:warning: only available for png files):
-    * Given the following header and/or footer template (using a `${image:PATH}` as a placeholder):
-        ```
-        ...
-        <image src="${image:./local_image_path/image.png}">
-        ...
-        ```
-        The result template will be:
-        ```
-        ...
-        <image src="data:image/png;base64,XXXXXXXXXXXXXX">
-        ...
-        ```
+
+- standard options of [headerTemplate and footerTemplate from Puppeteer](https://devdocs.io/puppeteer/index#pagepdfoptions)
+- expanded variables from meta tags of HTML page:
+  - Given the following HTML meta tag (using a `${META_KEY}` as a placeholder):
+    ```
+    <meta name="specificKey" content="A specific value">
+    ```
+    And the following header and/or footer template:
+    ```
+    ...
+    <span>${specificKey}</span>
+    ...
+    ```
+    The result template will be:
+    ```
+    ...
+    <span>A specific value</span>
+    ...
+    ```
+- images encoded as _base64_ from local files (:warning: only available for png files):
+  - Given the following header and/or footer template (using a `${image:PATH}` as a placeholder):
+    ```
+    ...
+    <image src="${image:./local_image_path/image.png}">
+    ...
+    ```
+    The result template will be:
+    ```
+    ...
+    <image src="data:image/png;base64,XXXXXXXXXXXXXX">
+    ...
+    ```

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ## Context
 
-This tool aim to **print pages from a website into PDF files**.  
+This tool aims to **print pages from a website into PDF files**.  
 To achieve that, the website **must follow the [sitemap protocol](https://www.sitemaps.org/protocol.html)**.
 
-*NB: this tool has been created originally to be able to print pages from a Hugo website, that's why the default value of the sitemap URL to check is **http://localhost:1313**.*
+*NB: this tool was originally created to print pages from a Hugo website, that's why the default value of the sitemap URL to check is **http://localhost:1313**.*
 
 ## How it works?
 
@@ -51,6 +51,7 @@ Common options:
   -t, --templateDir, --template-dir                   Relative path of the templates directory
                                                                                            [default: "./w2pdf_template"]
   -o, --outputDir, --output-dir                       Relative path of the output directory  [default: "./w2pdf_output"]
+      --pageSize, --page-size                         Page size / PaperFormat                   [string] [default: "a4"]
       --marginTop, --margin-top                       Margin top (50px or 0px)                                  [string]
       --marginBottom, --margin-bottom                 Margin bottom (50px or 0px)                               [string]
       --marginLeft, --margin-left                     Margin left                              [string] [default: "0px"]
@@ -124,8 +125,12 @@ $ npx website2pdf
 
 ## How to use Header and Footer?
 
-To include specific header and footer in PDF pages, two HTML files must be provided, named respectively **header.html** and **footer.html** (in **./w2pdf_template** by default).  
+You can choose the page dimension / page size with the `--pageSize` option. The default size is `A4` but can be any [PaperFormat](https://pptr.dev/api/puppeteer.paperformat).
+
+To include specific header and footer in PDF pages, two HTML files must be provided, named respectively **header.html** and **footer.html** (in **./w2pdf_template** by default).
+
 Because of a [limitation in puppeteer](https://github.com/puppeteer/puppeteer/issues/1853), a default margin must be set (at least for top and bottom) to display headers and footers.  
+
 By default website2pdf is setting the following margins depending on the `displayHeaderFooter` option (these default values can be override using the `marginX` options of website2pdf):
 * `displayHeaderFooter=false`
     ```
@@ -159,7 +164,7 @@ By default website2pdf is setting the following margins depending on the `displa
 The following types of configurations are available to expand header and footer:
 * standard options of [headerTemplate and footerTemplate from Puppeteer](https://devdocs.io/puppeteer/index#pagepdfoptions)
 * expanded variables from meta tags of HTML page:
-    * Given the following HTML meta tag (using a ${META_KEY} as a placeholder):
+    * Given the following HTML meta tag (using a `${META_KEY}` as a placeholder):
         ```
         <meta name="specificKey" content="A specific value">
         ```
@@ -175,8 +180,8 @@ The following types of configurations are available to expand header and footer:
         <span>A specific value</span>
         ...
         ```
-* images encoded as base64 from local files (:warning: only available for png files):
-    * Given the following header and/or footer template (using a ${image:PATH} as a placeholder):
+* images encoded as _base64_ from local files (:warning: only available for png files):
+    * Given the following header and/or footer template (using a `${image:PATH}` as a placeholder):
         ```
         ...
         <image src="${image:./local_image_path/image.png}">

--- a/src/cli/iArgumentsParser.ts
+++ b/src/cli/iArgumentsParser.ts
@@ -1,6 +1,6 @@
-import { PathLike } from 'fs-extra';
-import { PaperFormat } from 'puppeteer';
-import { Arguments, Argv } from 'yargs';
+import {PathLike} from 'fs-extra';
+import {PaperFormat} from 'puppeteer';
+import {Arguments, Argv} from 'yargs';
 
 export interface IArgumentsParser extends Argv {
   argv: ICliArguments;
@@ -11,12 +11,12 @@ export interface ICliArguments extends Arguments {
   debug: boolean;
   displayHeaderFooter: boolean;
   excludeUrls: string;
+  format: PaperFormat;
   marginBottom: string;
   marginLeft: string;
   marginRight: string;
   marginTop: string;
   outputDir: PathLike;
-  pageSize: PaperFormat;
   processPool: number;
   safeTitle: boolean;
   serveSitemap: string;

--- a/src/cli/iArgumentsParser.ts
+++ b/src/cli/iArgumentsParser.ts
@@ -7,20 +7,20 @@ export interface IArgumentsParser extends Argv {
 }
 
 export interface ICliArguments extends Arguments {
+  chromiumFlags: string;
   debug: boolean;
   displayHeaderFooter: boolean;
-  sitemapUrl: string;
-  templateDir: PathLike;
-  outputDir: PathLike;
-  marginTop: string;
+  excludeUrls: string;
   marginBottom: string;
   marginLeft: string;
   marginRight: string;
-  chromiumFlags: string;
-  excludeUrls: string;
-  safeTitle: boolean;
-  urlTitle: boolean;
-  processPool: number;
-  serveSitemap: string;
+  marginTop: string;
+  outputDir: PathLike;
   pageSize: PaperFormat;
+  processPool: number;
+  safeTitle: boolean;
+  serveSitemap: string;
+  sitemapUrl: string;
+  templateDir: PathLike;
+  urlTitle: boolean;
 }

--- a/src/cli/iArgumentsParser.ts
+++ b/src/cli/iArgumentsParser.ts
@@ -1,5 +1,6 @@
-import {PathLike} from 'fs-extra';
-import {Arguments, Argv} from 'yargs';
+import { PathLike } from 'fs-extra';
+import { PaperFormat } from 'puppeteer';
+import { Arguments, Argv } from 'yargs';
 
 export interface IArgumentsParser extends Argv {
   argv: ICliArguments;
@@ -21,4 +22,5 @@ export interface ICliArguments extends Arguments {
   urlTitle: boolean;
   processPool: number;
   serveSitemap: string;
+  pageSize: PaperFormat;
 }

--- a/src/cli/website2pdfCli.ts
+++ b/src/cli/website2pdfCli.ts
@@ -1,5 +1,5 @@
 import kleur = require('kleur');
-import {hideBin} from 'yargs/helpers';
+import { hideBin } from 'yargs/helpers';
 import {
   CHROMIUM_FLAGS_OPTION,
   CLI_USAGE,
@@ -15,15 +15,16 @@ import {
   MARGIN_RIGHT_OPTION,
   MARGIN_TOP_OPTION,
   OUTPUT_DIR_OPTION,
+  PAGE_SIZE_OPTION,
   PROCESS_POOL_OPTION,
   SAFE_TITLE_OPTION,
   SERVE_SITEMAP_OPTION,
   SITEMAP_URL_OPTION,
   TEMPLATE_DIR_OPTION,
-  URL_TITLE_OPTION,
+  URL_TITLE_OPTION
 } from '../utils/const';
-import {getOutputWidth} from '../utils/helpers';
-import {IArgumentsParser, ICliArguments} from './iArgumentsParser';
+import { getOutputWidth } from '../utils/helpers';
+import { IArgumentsParser, ICliArguments } from './iArgumentsParser';
 const yargs = require('yargs');
 
 export class Website2PdfCli {
@@ -81,6 +82,7 @@ export class Website2PdfCli {
           `$0 --${OUTPUT_DIR_OPTION} "./output"`,
           'Use specific output directory',
         ],
+        [`$0 --${PAGE_SIZE_OPTION}="a4"`, 'Set PaperFormat type'],
         [
           `$0 --${DISPLAY_HEADER_FOOTER_OPTION} --${MARGIN_LEFT_OPTION} "50px" --${MARGIN_RIGHT_OPTION} "50px"`,
           'Use header and footer and set specific margins',
@@ -200,6 +202,13 @@ export class Website2PdfCli {
           type: 'boolean',
           default: false,
           description: 'Generate file title using last URL fragment',
+          group: this.GROUPS.COMMONS,
+        },
+        pageSize: {
+          alias: [`${PAGE_SIZE_OPTION}`],
+          type: 'string',
+          default: 'a4',
+          description: 'Choose PaperFormat size',
           group: this.GROUPS.COMMONS,
         },
         processPool: {

--- a/src/cli/website2pdfCli.ts
+++ b/src/cli/website2pdfCli.ts
@@ -1,30 +1,35 @@
 import kleur = require('kleur');
-import { hideBin } from 'yargs/helpers';
+import {hideBin} from 'yargs/helpers';
 import {
   CHROMIUM_FLAGS_OPTION,
   CLI_USAGE,
+  DEFAULT_FORMAT,
+  DEFAULT_HEADER_FOOTER,
   DEFAULT_MARGIN_MAX,
   DEFAULT_MARGIN_MIN,
   DEFAULT_OUTPUT_DIR,
+  DEFAULT_PROCESS_POOL,
+  DEFAULT_SAFE_TITLE,
   DEFAULT_SITEMAP_URL,
   DEFAULT_TEMPLATE_DIR,
+  DEFAULT_URL_TITLE,
   DISPLAY_HEADER_FOOTER_OPTION,
   EXCLUDE_URLS_OPTION,
+  FORMAT_OPTION,
   MARGIN_BOTTOM_OPTION,
   MARGIN_LEFT_OPTION,
   MARGIN_RIGHT_OPTION,
   MARGIN_TOP_OPTION,
   OUTPUT_DIR_OPTION,
-  PAGE_SIZE_OPTION,
   PROCESS_POOL_OPTION,
   SAFE_TITLE_OPTION,
   SERVE_SITEMAP_OPTION,
   SITEMAP_URL_OPTION,
   TEMPLATE_DIR_OPTION,
-  URL_TITLE_OPTION
+  URL_TITLE_OPTION,
 } from '../utils/const';
-import { getOutputWidth } from '../utils/helpers';
-import { IArgumentsParser, ICliArguments } from './iArgumentsParser';
+import {getOutputWidth} from '../utils/helpers';
+import {IArgumentsParser, ICliArguments} from './iArgumentsParser';
 const yargs = require('yargs');
 
 export class Website2PdfCli {
@@ -67,7 +72,7 @@ export class Website2PdfCli {
       .alias('h', 'help')
       .example([
         [
-          `$0 --${SITEMAP_URL_OPTION} "http://localhost:80/sitemap.xml"`,
+          `$0 --${SITEMAP_URL_OPTION}="http://localhost:80/sitemap.xml"`,
           'Use specific sitemap URL',
         ],
         [
@@ -75,16 +80,16 @@ export class Website2PdfCli {
           'Print PDFs with header and footer',
         ],
         [
-          `$0 --${TEMPLATE_DIR_OPTION} "./templates"`,
+          `$0 --${TEMPLATE_DIR_OPTION}="./templates"`,
           'Use specific template directory',
         ],
         [
-          `$0 --${OUTPUT_DIR_OPTION} "./output"`,
+          `$0 --${OUTPUT_DIR_OPTION}="./output"`,
           'Use specific output directory',
         ],
-        [`$0 --${PAGE_SIZE_OPTION}="a4"`, 'Set PaperFormat type'],
+        [`$0 --${FORMAT_OPTION}="a3"`, 'Set PaperFormat type'],
         [
-          `$0 --${DISPLAY_HEADER_FOOTER_OPTION} --${MARGIN_LEFT_OPTION} "50px" --${MARGIN_RIGHT_OPTION} "50px"`,
+          `$0 --${DISPLAY_HEADER_FOOTER_OPTION} --${MARGIN_LEFT_OPTION}="50px" --${MARGIN_RIGHT_OPTION}="50px"`,
           'Use header and footer and set specific margins',
         ],
         [
@@ -104,7 +109,7 @@ export class Website2PdfCli {
           'Generate file title using last URL fragment',
         ],
         [
-          `$0 --${PROCESS_POOL_OPTION}`,
+          `$0 --${PROCESS_POOL_OPTION}=20`,
           'Use specific count of parallelized process',
         ],
         [`$0 --${SERVE_SITEMAP_OPTION}="sitemap.xml"`, 'Serve a local sitemap'],
@@ -126,7 +131,7 @@ export class Website2PdfCli {
         displayHeaderFooter: {
           alias: [`${DISPLAY_HEADER_FOOTER_OPTION}`],
           type: 'boolean',
-          default: false,
+          default: DEFAULT_HEADER_FOOTER,
           description: 'Turn on header and footer printing',
           group: this.GROUPS.COMMONS,
         },
@@ -193,28 +198,29 @@ export class Website2PdfCli {
         safeTitle: {
           alias: [`${SAFE_TITLE_OPTION}`],
           type: 'boolean',
-          default: false,
+          default: DEFAULT_SAFE_TITLE,
           description: 'Safely generate file title by replacing special chars',
           group: this.GROUPS.COMMONS,
         },
         urlTitle: {
           alias: [`${URL_TITLE_OPTION}`],
           type: 'boolean',
-          default: false,
+          default: DEFAULT_URL_TITLE,
           description: 'Generate file title using last URL fragment',
           group: this.GROUPS.COMMONS,
         },
-        pageSize: {
-          alias: [`${PAGE_SIZE_OPTION}`],
+        format: {
+          alias: [`${FORMAT_OPTION}`],
           type: 'string',
-          default: 'a4',
-          description: 'Choose PaperFormat size',
+          default: DEFAULT_FORMAT,
+          description: 'Set PaperFormat of generated PDF',
           group: this.GROUPS.COMMONS,
+          nargs: 1,
         },
         processPool: {
           alias: [`${PROCESS_POOL_OPTION}`],
           type: 'number',
-          default: 10,
+          default: DEFAULT_PROCESS_POOL,
           description: 'Pool of parallelized process',
           group: this.GROUPS.COMMONS,
           nargs: 1,

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import * as http from 'http';
-import { cyan } from 'kleur';
+import {cyan} from 'kleur';
 
 export const MAX_TTY_LENGTH = 120;
 
@@ -12,7 +12,7 @@ export const MARGIN_LEFT_OPTION = 'margin-left';
 export const MARGIN_RIGHT_OPTION = 'margin-right';
 export const MARGIN_TOP_OPTION = 'margin-top';
 export const OUTPUT_DIR_OPTION = 'output-dir';
-export const PAGE_SIZE_OPTION = 'page-size';
+export const FORMAT_OPTION = 'format';
 export const PROCESS_POOL_OPTION = 'process-pool';
 export const SAFE_TITLE_OPTION = 'safe-title';
 export const SERVE_SITEMAP_OPTION = 'serve-sitemap';
@@ -21,12 +21,13 @@ export const TEMPLATE_DIR_OPTION = 'template-dir';
 export const URL_TITLE_OPTION = 'url-title';
 
 export const DEFAULT_FOOTER_FILE = 'footer.html';
+export const DEFAULT_FORMAT = 'a4';
 export const DEFAULT_HEADER_FILE = 'header.html';
+export const DEFAULT_HEADER_FOOTER = false;
 export const DEFAULT_HOST = 'localhost';
 export const DEFAULT_MARGIN_MAX = '50px';
 export const DEFAULT_MARGIN_MIN = '0px';
 export const DEFAULT_OUTPUT_DIR = './w2pdf_output';
-export const DEFAULT_PAGE_SIZE = 'a4';
 export const DEFAULT_PORT = '1313';
 export const DEFAULT_PROCESS_POOL = 10;
 export const DEFAULT_SAFE_TITLE = false;

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -3,37 +3,38 @@ import * as http from 'http';
 import { cyan } from 'kleur';
 
 export const MAX_TTY_LENGTH = 120;
-export const SITEMAP_URL_OPTION = 'sitemap-url';
+
+export const CHROMIUM_FLAGS_OPTION = 'chromium-flags';
 export const DISPLAY_HEADER_FOOTER_OPTION = 'display-header-footer';
-export const TEMPLATE_DIR_OPTION = 'template-dir';
-export const OUTPUT_DIR_OPTION = 'output-dir';
-export const MARGIN_TOP_OPTION = 'margin-top';
+export const EXCLUDE_URLS_OPTION = 'exclude-urls';
 export const MARGIN_BOTTOM_OPTION = 'margin-bottom';
 export const MARGIN_LEFT_OPTION = 'margin-left';
 export const MARGIN_RIGHT_OPTION = 'margin-right';
-export const CHROMIUM_FLAGS_OPTION = 'chromium-flags';
-export const EXCLUDE_URLS_OPTION = 'exclude-urls';
-export const SAFE_TITLE_OPTION = 'safe-title';
-export const URL_TITLE_OPTION = 'url-title';
-export const PROCESS_POOL_OPTION = 'process-pool';
-export const SERVE_SITEMAP_OPTION = 'serve-sitemap';
+export const MARGIN_TOP_OPTION = 'margin-top';
+export const OUTPUT_DIR_OPTION = 'output-dir';
 export const PAGE_SIZE_OPTION = 'page-size';
+export const PROCESS_POOL_OPTION = 'process-pool';
+export const SAFE_TITLE_OPTION = 'safe-title';
+export const SERVE_SITEMAP_OPTION = 'serve-sitemap';
+export const SITEMAP_URL_OPTION = 'sitemap-url';
+export const TEMPLATE_DIR_OPTION = 'template-dir';
+export const URL_TITLE_OPTION = 'url-title';
 
-export const DEFAULT_TEMPLATE_DIR = './w2pdf_template';
-export const DEFAULT_OUTPUT_DIR = './w2pdf_output';
+export const DEFAULT_FOOTER_FILE = 'footer.html';
+export const DEFAULT_HEADER_FILE = 'header.html';
+export const DEFAULT_HOST = 'localhost';
 export const DEFAULT_MARGIN_MAX = '50px';
 export const DEFAULT_MARGIN_MIN = '0px';
-export const DEFAULT_HEADER_FILE = 'header.html';
-export const DEFAULT_FOOTER_FILE = 'footer.html';
-export const DEFAULT_HOST = 'localhost';
+export const DEFAULT_OUTPUT_DIR = './w2pdf_output';
 export const DEFAULT_PAGE_SIZE = 'a4';
 export const DEFAULT_PORT = '1313';
-export const DEFAULT_SITEMAP_NAME = 'sitemap.xml';
-export const DEFAULT_SITEMAP_HOST = `http://${DEFAULT_HOST}:${DEFAULT_PORT}`;
-export const DEFAULT_SITEMAP_URL = `${DEFAULT_SITEMAP_HOST}/${DEFAULT_SITEMAP_NAME}`;
-export const DEFAULT_SAFE_TITLE = false;
-export const DEFAULT_URL_TITLE = false;
 export const DEFAULT_PROCESS_POOL = 10;
+export const DEFAULT_SAFE_TITLE = false;
+export const DEFAULT_SITEMAP_HOST = `http://${DEFAULT_HOST}:${DEFAULT_PORT}`;
+export const DEFAULT_SITEMAP_NAME = 'sitemap.xml';
+export const DEFAULT_SITEMAP_URL = `${DEFAULT_SITEMAP_HOST}/${DEFAULT_SITEMAP_NAME}`;
+export const DEFAULT_TEMPLATE_DIR = './w2pdf_template';
+export const DEFAULT_URL_TITLE = false;
 export const fxpOptions = {
   ignoreAttributes: true,
   parseNodeValue: true,

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import * as http from 'http';
-import {cyan} from 'kleur';
+import { cyan } from 'kleur';
 
 export const MAX_TTY_LENGTH = 120;
 export const SITEMAP_URL_OPTION = 'sitemap-url';
@@ -17,6 +17,7 @@ export const SAFE_TITLE_OPTION = 'safe-title';
 export const URL_TITLE_OPTION = 'url-title';
 export const PROCESS_POOL_OPTION = 'process-pool';
 export const SERVE_SITEMAP_OPTION = 'serve-sitemap';
+export const PAGE_SIZE_OPTION = 'page-size';
 
 export const DEFAULT_TEMPLATE_DIR = './w2pdf_template';
 export const DEFAULT_OUTPUT_DIR = './w2pdf_output';
@@ -25,6 +26,7 @@ export const DEFAULT_MARGIN_MIN = '0px';
 export const DEFAULT_HEADER_FILE = 'header.html';
 export const DEFAULT_FOOTER_FILE = 'footer.html';
 export const DEFAULT_HOST = 'localhost';
+export const DEFAULT_PAGE_SIZE = 'a4';
 export const DEFAULT_PORT = '1313';
 export const DEFAULT_SITEMAP_NAME = 'sitemap.xml';
 export const DEFAULT_SITEMAP_HOST = `http://${DEFAULT_HOST}:${DEFAULT_PORT}`;

--- a/src/website2pdf.ts
+++ b/src/website2pdf.ts
@@ -1,26 +1,26 @@
 #!/usr/bin/env node
 /* eslint-disable @typescript-eslint/no-explicit-any*/
-import {PromisePool} from '@supercharge/promise-pool';
+import { PromisePool } from '@supercharge/promise-pool';
 import * as fs from 'fs-extra';
-import {red} from 'kleur';
+import { red } from 'kleur';
 import * as path from 'path';
 import * as puppeteer from 'puppeteer';
 import 'reflect-metadata';
-import {URL} from 'url';
-import {ICliArguments} from './cli/iArgumentsParser';
-import {Website2PdfCli} from './cli/website2pdfCli';
-import {PdfTemplate} from './model/pdfTemplate';
-import {Website} from './model/website';
-import {WebsiteSitemap} from './model/websiteSitemap';
+import { URL } from 'url';
+import { ICliArguments } from './cli/iArgumentsParser';
+import { Website2PdfCli } from './cli/website2pdfCli';
+import { PdfTemplate } from './model/pdfTemplate';
+import { Website } from './model/website';
+import { WebsiteSitemap } from './model/websiteSitemap';
 import {
   headerFactory,
   interpolate,
   puppeteerBrowserLaunchArgs,
   toFilename,
-  toFilePath,
+  toFilePath
 } from './utils/helpers';
-import {logger} from './utils/logger';
-import {PrintResults, STATUS_ERROR, STATUS_PRINTED} from './utils/stats';
+import { logger } from './utils/logger';
+import { PrintResults, STATUS_ERROR, STATUS_PRINTED } from './utils/stats';
 
 export class Website2Pdf {
   static async main(): Promise<void> {
@@ -201,7 +201,7 @@ async function pageToPDF(
               .pdf({
                 timeout: 0,
                 path: filePath,
-                format: 'a4',
+                format: cliArgs.pageSize,
                 displayHeaderFooter: cliArgs.displayHeaderFooter,
                 headerTemplate: interpolate(pdfTemplate.header, metadatas),
                 footerTemplate: interpolate(pdfTemplate.footer, metadatas),

--- a/src/website2pdf.ts
+++ b/src/website2pdf.ts
@@ -1,26 +1,26 @@
 #!/usr/bin/env node
 /* eslint-disable @typescript-eslint/no-explicit-any*/
-import { PromisePool } from '@supercharge/promise-pool';
+import {PromisePool} from '@supercharge/promise-pool';
 import * as fs from 'fs-extra';
-import { red } from 'kleur';
+import {red} from 'kleur';
 import * as path from 'path';
 import * as puppeteer from 'puppeteer';
 import 'reflect-metadata';
-import { URL } from 'url';
-import { ICliArguments } from './cli/iArgumentsParser';
-import { Website2PdfCli } from './cli/website2pdfCli';
-import { PdfTemplate } from './model/pdfTemplate';
-import { Website } from './model/website';
-import { WebsiteSitemap } from './model/websiteSitemap';
+import {URL} from 'url';
+import {ICliArguments} from './cli/iArgumentsParser';
+import {Website2PdfCli} from './cli/website2pdfCli';
+import {PdfTemplate} from './model/pdfTemplate';
+import {Website} from './model/website';
+import {WebsiteSitemap} from './model/websiteSitemap';
 import {
   headerFactory,
   interpolate,
   puppeteerBrowserLaunchArgs,
   toFilename,
-  toFilePath
+  toFilePath,
 } from './utils/helpers';
-import { logger } from './utils/logger';
-import { PrintResults, STATUS_ERROR, STATUS_PRINTED } from './utils/stats';
+import {logger} from './utils/logger';
+import {PrintResults, STATUS_ERROR, STATUS_PRINTED} from './utils/stats';
 
 export class Website2Pdf {
   static async main(): Promise<void> {
@@ -201,7 +201,7 @@ async function pageToPDF(
               .pdf({
                 timeout: 0,
                 path: filePath,
-                format: cliArgs.pageSize,
+                format: cliArgs.format,
                 displayHeaderFooter: cliArgs.displayHeaderFooter,
                 headerTemplate: interpolate(pdfTemplate.header, metadatas),
                 footerTemplate: interpolate(pdfTemplate.footer, metadatas),

--- a/test/cli/test-website2pdfCli.ts
+++ b/test/cli/test-website2pdfCli.ts
@@ -4,6 +4,7 @@ import {Website2PdfCli} from '../../src/cli/website2pdfCli';
 import {Website} from '../../src/model/website';
 import {
   CHROMIUM_FLAGS_OPTION,
+  DEFAULT_FORMAT,
   DEFAULT_MARGIN_MAX,
   DEFAULT_MARGIN_MIN,
   DEFAULT_OUTPUT_DIR,
@@ -14,6 +15,7 @@ import {
   DEFAULT_URL_TITLE,
   DISPLAY_HEADER_FOOTER_OPTION,
   EXCLUDE_URLS_OPTION,
+  FORMAT_OPTION,
   MARGIN_BOTTOM_OPTION,
   MARGIN_LEFT_OPTION,
   MARGIN_RIGHT_OPTION,
@@ -30,6 +32,7 @@ import {
   SPECIFIC_CHROMIUM_FLAGS,
   SPECIFIC_DIR,
   SPECIFIC_EXCLUDE_REGEX,
+  SPECIFIC_FORMAT,
   SPECIFIC_PROCESS_POOL,
   SPECIFIC_SERVED_SITEMAP,
   SPECIFIC_URL,
@@ -81,17 +84,18 @@ describe('Website2Pdf CLI tests', () => {
     const cli = new Website2PdfCli();
     return cli.parse().then(argv => {
       expect(argv.displayHeaderFooter).to.be.equal(false);
-      expect(argv.sitemapUrl).to.be.equal(DEFAULT_SITEMAP_URL);
-      expect(argv.templateDir).to.be.equal(DEFAULT_TEMPLATE_DIR);
-      expect(argv.outputDir).to.be.equal(DEFAULT_OUTPUT_DIR);
+      expect(argv.format).to.be.equal(DEFAULT_FORMAT);
       expect(argv.marginTop).to.be.equal(DEFAULT_MARGIN_MIN);
       expect(argv.marginBottom).to.be.equal(DEFAULT_MARGIN_MIN);
       expect(argv.marginLeft).to.be.equal(DEFAULT_MARGIN_MIN);
       expect(argv.marginRight).to.be.equal(DEFAULT_MARGIN_MIN);
-      expect(argv.safeTitle).to.be.equal(DEFAULT_SAFE_TITLE);
-      expect(argv.urlTitle).to.be.equal(DEFAULT_URL_TITLE);
+      expect(argv.outputDir).to.be.equal(DEFAULT_OUTPUT_DIR);
       expect(argv.processPool).to.be.equal(DEFAULT_PROCESS_POOL);
+      expect(argv.safeTitle).to.be.equal(DEFAULT_SAFE_TITLE);
       expect(argv.serveSitemap).to.be.undefined;
+      expect(argv.sitemapUrl).to.be.equal(DEFAULT_SITEMAP_URL);
+      expect(argv.templateDir).to.be.equal(DEFAULT_TEMPLATE_DIR);
+      expect(argv.urlTitle).to.be.equal(DEFAULT_URL_TITLE);
       const website: Website = new Website();
       expect(website.websiteURL.sitemapURL.toString()).to.equal(
         DEFAULT_SITEMAP_URL
@@ -364,6 +368,26 @@ describe('Website2Pdf CLI tests', () => {
     sinonMock.processExit = true;
     sinonMock.sinonSetStubs();
     mockArgs([`--${PROCESS_POOL_OPTION}`]);
+    const cli = new Website2PdfCli();
+    return cli.parse().then(() => {
+      expect(console.error).to.be.called;
+      expect(process.exit).to.be.called;
+    });
+  });
+  it(`parse should have specific ${FORMAT_OPTION} argument when ${FORMAT_OPTION} option`, () => {
+    setChaiAsPromised();
+    mockArgs([`--${FORMAT_OPTION}=${SPECIFIC_FORMAT}`]);
+    const cli = new Website2PdfCli();
+    return cli.parse().then(argv => {
+      expect(argv.format).to.be.equal(SPECIFIC_FORMAT);
+    });
+  });
+  it(`parse should display error and exit when ${FORMAT_OPTION} option is empty`, () => {
+    setChaiAsPromised();
+    sinonMock.consoleError = true;
+    sinonMock.processExit = true;
+    sinonMock.sinonSetStubs();
+    mockArgs([`--${FORMAT_OPTION}`]);
     const cli = new Website2PdfCli();
     return cli.parse().then(() => {
       expect(console.error).to.be.called;

--- a/test/model/test-website.ts
+++ b/test/model/test-website.ts
@@ -1,26 +1,28 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import axios from 'axios';
-import { expect } from 'chai';
+import {expect} from 'chai';
 import * as path from 'path';
 import 'reflect-metadata';
-import { Website } from '../../src/model/website';
+import {Website} from '../../src/model/website';
 import {
   ERROR_UNKNOWN_XML_SCHEMA,
-  Website2PdfError
+  Website2PdfError,
 } from '../../src/model/website2pdfError';
 import {
   DEFAULT_SITEMAP_HOST,
   DEFAULT_SITEMAP_NAME,
   DEFAULT_SITEMAP_URL,
   SERVE_SITEMAP_OPTION,
-  SITEMAP_URL_OPTION
+  SITEMAP_URL_OPTION,
 } from '../../src/utils/const';
 import {
   ABSOLUTE_URL,
   DUMMY_CLIARGS,
   EN_HOMEPAGE_URL,
   FR_HOMEPAGE_URL,
-  RELATIVE_URL, SITEMAPINDEX_EMPTY_PAGE, SITEMAP_EMPTY_PAGE,
+  RELATIVE_URL,
+  SITEMAPINDEX_EMPTY_PAGE,
+  SITEMAP_EMPTY_PAGE,
   SITEMAP_EN_ABSURL,
   SITEMAP_EN_PAGE,
   SITEMAP_EXTENDED_PAGE,
@@ -28,14 +30,15 @@ import {
   SITEMAP_FR_PAGE,
   SITEMAP_INVALID_PAGE,
   SITEMAP_STANDARD_PAGE,
-  SITEMAP_UNKNOWN_PAGE, testResourcesPath
+  SITEMAP_UNKNOWN_PAGE,
+  testResourcesPath,
 } from '../testUtils/const';
-import { setChaiAsPromised } from '../testUtils/helpers';
+import {setChaiAsPromised} from '../testUtils/helpers';
 import {
   AxiosMethodStub,
   createSandbox,
   restoreSandbox,
-  setAxiosStub
+  setAxiosStub,
 } from '../testUtils/sinonStubs';
 
 describe('Website model tests', () => {

--- a/test/model/test-website.ts
+++ b/test/model/test-website.ts
@@ -1,28 +1,26 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import axios from 'axios';
-import {expect} from 'chai';
+import { expect } from 'chai';
 import * as path from 'path';
 import 'reflect-metadata';
-import {Website} from '../../src/model/website';
+import { Website } from '../../src/model/website';
 import {
   ERROR_UNKNOWN_XML_SCHEMA,
-  Website2PdfError,
+  Website2PdfError
 } from '../../src/model/website2pdfError';
 import {
   DEFAULT_SITEMAP_HOST,
   DEFAULT_SITEMAP_NAME,
   DEFAULT_SITEMAP_URL,
   SERVE_SITEMAP_OPTION,
-  SITEMAP_URL_OPTION,
+  SITEMAP_URL_OPTION
 } from '../../src/utils/const';
 import {
   ABSOLUTE_URL,
   DUMMY_CLIARGS,
   EN_HOMEPAGE_URL,
   FR_HOMEPAGE_URL,
-  RELATIVE_URL,
-  SITEMAPINDEX_EMPTY_PAGE,
-  SITEMAP_EMPTY_PAGE,
+  RELATIVE_URL, SITEMAPINDEX_EMPTY_PAGE, SITEMAP_EMPTY_PAGE,
   SITEMAP_EN_ABSURL,
   SITEMAP_EN_PAGE,
   SITEMAP_EXTENDED_PAGE,
@@ -30,15 +28,14 @@ import {
   SITEMAP_FR_PAGE,
   SITEMAP_INVALID_PAGE,
   SITEMAP_STANDARD_PAGE,
-  SITEMAP_UNKNOWN_PAGE,
-  testResourcesPath,
+  SITEMAP_UNKNOWN_PAGE, testResourcesPath
 } from '../testUtils/const';
-import {setChaiAsPromised} from '../testUtils/helpers';
+import { setChaiAsPromised } from '../testUtils/helpers';
 import {
   AxiosMethodStub,
   createSandbox,
   restoreSandbox,
-  setAxiosStub,
+  setAxiosStub
 } from '../testUtils/sinonStubs';
 
 describe('Website model tests', () => {

--- a/test/testUtils/const.ts
+++ b/test/testUtils/const.ts
@@ -1,15 +1,16 @@
 /* c8 ignore start */
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import {ICliArguments} from '../../src/cli/iArgumentsParser';
+import { ICliArguments } from '../../src/cli/iArgumentsParser';
 import {
   DEFAULT_MARGIN_MIN,
   DEFAULT_OUTPUT_DIR,
+  DEFAULT_PAGE_SIZE,
   DEFAULT_PROCESS_POOL,
   DEFAULT_SITEMAP_HOST,
   DEFAULT_SITEMAP_NAME,
   DEFAULT_SITEMAP_URL,
-  DEFAULT_TEMPLATE_DIR,
+  DEFAULT_TEMPLATE_DIR
 } from '../../src/utils/const';
 
 export const rootPath: string = path.join(process.cwd());
@@ -56,6 +57,7 @@ export const DUMMY_CLIARGS: ICliArguments = {
   urlTitle: false,
   processPool: DEFAULT_PROCESS_POOL,
   serveSitemap: DEFAULT_SITEMAP_NAME,
+  pageSize: DEFAULT_PAGE_SIZE,
 };
 
 export const ABSOLUTE_URL = 'absolute/url';

--- a/test/testUtils/const.ts
+++ b/test/testUtils/const.ts
@@ -33,31 +33,31 @@ export const testTemplatesImagePath: string = path.join(
   testResourcesPath,
   `${DEFAULT_TEMPLATE_DIR}_image`
 );
-export const SPECIFIC_URL = `https://example.com/${DEFAULT_SITEMAP_NAME}`;
-export const SPECIFIC_SERVED_SITEMAP = 'anotherSitemap.xml';
-export const SPECIFIC_DIR = './aSpecificDir/';
 export const SPECIFIC_CHROMIUM_FLAGS = '--no-sandbox';
+export const SPECIFIC_DIR = './aSpecificDir/';
 export const SPECIFIC_EXCLUDE_REGEX = '\\/fr\\/';
 export const SPECIFIC_PROCESS_POOL = 20;
+export const SPECIFIC_SERVED_SITEMAP = 'anotherSitemap.xml';
+export const SPECIFIC_URL = `https://example.com/${DEFAULT_SITEMAP_NAME}`;
 export const DUMMY_CLIARGS: ICliArguments = {
   _: [],
   $0: '',
-  excludeUrls: SPECIFIC_EXCLUDE_REGEX,
+  chromiumFlags: '',
   debug: false,
-  sitemapUrl: DEFAULT_SITEMAP_URL,
   displayHeaderFooter: false,
-  templateDir: DEFAULT_TEMPLATE_DIR,
-  outputDir: DEFAULT_OUTPUT_DIR,
+  excludeUrls: SPECIFIC_EXCLUDE_REGEX,
+  marginBottom: DEFAULT_MARGIN_MIN,
   marginLeft: DEFAULT_MARGIN_MIN,
   marginRight: DEFAULT_MARGIN_MIN,
   marginTop: DEFAULT_MARGIN_MIN,
-  marginBottom: DEFAULT_MARGIN_MIN,
-  chromiumFlags: '',
-  safeTitle: false,
-  urlTitle: false,
-  processPool: DEFAULT_PROCESS_POOL,
-  serveSitemap: DEFAULT_SITEMAP_NAME,
+  outputDir: DEFAULT_OUTPUT_DIR,
   pageSize: DEFAULT_PAGE_SIZE,
+  processPool: DEFAULT_PROCESS_POOL,
+  safeTitle: false,
+  serveSitemap: DEFAULT_SITEMAP_NAME,
+  sitemapUrl: DEFAULT_SITEMAP_URL,
+  templateDir: DEFAULT_TEMPLATE_DIR,
+  urlTitle: false,
 };
 
 export const ABSOLUTE_URL = 'absolute/url';

--- a/test/testUtils/const.ts
+++ b/test/testUtils/const.ts
@@ -1,16 +1,16 @@
 /* c8 ignore start */
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { ICliArguments } from '../../src/cli/iArgumentsParser';
+import {ICliArguments} from '../../src/cli/iArgumentsParser';
 import {
+  DEFAULT_FORMAT,
   DEFAULT_MARGIN_MIN,
   DEFAULT_OUTPUT_DIR,
-  DEFAULT_PAGE_SIZE,
   DEFAULT_PROCESS_POOL,
   DEFAULT_SITEMAP_HOST,
   DEFAULT_SITEMAP_NAME,
   DEFAULT_SITEMAP_URL,
-  DEFAULT_TEMPLATE_DIR
+  DEFAULT_TEMPLATE_DIR,
 } from '../../src/utils/const';
 
 export const rootPath: string = path.join(process.cwd());
@@ -36,6 +36,7 @@ export const testTemplatesImagePath: string = path.join(
 export const SPECIFIC_CHROMIUM_FLAGS = '--no-sandbox';
 export const SPECIFIC_DIR = './aSpecificDir/';
 export const SPECIFIC_EXCLUDE_REGEX = '\\/fr\\/';
+export const SPECIFIC_FORMAT = 'a3';
 export const SPECIFIC_PROCESS_POOL = 20;
 export const SPECIFIC_SERVED_SITEMAP = 'anotherSitemap.xml';
 export const SPECIFIC_URL = `https://example.com/${DEFAULT_SITEMAP_NAME}`;
@@ -46,12 +47,12 @@ export const DUMMY_CLIARGS: ICliArguments = {
   debug: false,
   displayHeaderFooter: false,
   excludeUrls: SPECIFIC_EXCLUDE_REGEX,
+  format: DEFAULT_FORMAT,
   marginBottom: DEFAULT_MARGIN_MIN,
   marginLeft: DEFAULT_MARGIN_MIN,
   marginRight: DEFAULT_MARGIN_MIN,
   marginTop: DEFAULT_MARGIN_MIN,
   outputDir: DEFAULT_OUTPUT_DIR,
-  pageSize: DEFAULT_PAGE_SIZE,
   processPool: DEFAULT_PROCESS_POOL,
   safeTitle: false,
   serveSitemap: DEFAULT_SITEMAP_NAME,


### PR DESCRIPTION
❤️ 🙇 thank you for your excellent tool! 

We're using it to generate a "Print" book version of our website: https://github.com/whyboris/utilitarianism.net/pull/89 

`A4` paper size is excellent for desktop, but reading on a tablet makes the font too small, so having an option in your CLI would be great. I was able to manually change the [format: 'a4'](https://github.com/jgazeau/website2pdf/blob/main/src/website2pdf.ts#L204) in my `node_modules` folder and output a beautiful PDF 😍 

With this PR I could do it directly from my script without hacking node_modules :trollface: 

Please check if I added the feature correctly - I'm not 100% sure.

The first commit adds all the details, and the second commit _alphabetizes_ various blocks of constants and keys (I think this is an improvement).

I'm happy to adjust the PR as you recommend 🤝 perhaps instead of `paperSize` it should be a different name? 🤷‍♂️ Alternatively, commit any changes to this branch as you see fit 👍 

`npm run test` passes but code coverage is probably lower 😅  - also I'm sorry my editor auto-added spaces around `{ ` and ` }` 

While I added a note in the _README_, I'll add it here: the paper size options are a string from this list: [puppeteer.paperformat](https://pptr.dev/api/puppeteer.paperformat)

I found out that I could adjust your CLI by reading [your comment](https://github.com/jgazeau/website2pdf/issues/30#issuecomment-1133841916)

Cheers!
